### PR TITLE
Include vite as a dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "devDependencies": {
     "@sveltejs/adapter-static": "^1.0.0-next.26",
     "@sveltejs/kit": "next",
-    "svelte": "^3.44.0"
+    "svelte": "^3.44.0",
+    "vite": "^3.1.8"
   },
   "type": "module"
 }


### PR DESCRIPTION
`npm install` led to an error until I installed vite